### PR TITLE
Add import raw mode

### DIFF
--- a/src/GestDsk.cpp
+++ b/src/GestDsk.cpp
@@ -895,7 +895,7 @@ bool DSK::PutFileInDsk(string Masque, int TypeModeImport,
 	fclose( Hfile );
 
 	// Check if file already has an header
-	bool IsAmsdos = CheckAmsdos(Buff);
+	bool IsAmsdos = (TypeModeImport != MODE_RAW) &&  CheckAmsdos(Buff);
 
 	// Force binary mode if a load or execution address is specified
 	if (loadAddress != 0 || exeAddress != 0)
@@ -944,6 +944,8 @@ bool DSK::PutFileInDsk(string Masque, int TypeModeImport,
 			else
 				cout << "File already has an header\n";
 		break;
+		case MODE_RAW :
+			cout << "Using raw mode, no header\n";
 
 	}
 

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -296,7 +296,7 @@ void help(void)
 	cout << "-d : list a Dams file                  iDSK floppy.dsk -d myprog.dms" << endl;
 	cout << "-h : list a binary file as Hexadecimal iDSK floppy.dsk -h myprog.bin" << endl;
 	cout << "-i : Import file                       iDSK floppy.dsk -i myprog.bas" << endl
-		 << " -t : fileType (0=ASCII/1=BINARY)           ... -t 1" << endl;
+		 << " -t : fileType (0=ASCII/1=BINARY/2=raw)     ... -t 1" << endl;
 	cout << " -e : hex Execute address of file           ... -e C000 -t 1" << endl;
 	cout << " -c : hex loading address of file           ... -e C000 -c 4000 -t 1" << endl;
 	cout << " -f : Force overwriting if file exists      ... -f" << endl

--- a/src/MyType.h
+++ b/src/MyType.h
@@ -14,6 +14,7 @@ typedef    unsigned long        DWORD;  /* unsigned 32-bit type */
 #define FALSE 0
 #define MODE_ASCII 0
 #define MODE_BINAIRE 1
+#define MODE_RAW 2
 
 
 #endif /*MYTYPE_H_*/


### PR DESCRIPTION
Hello
This adds a raw import mode, as type 2. It imports the files without adding or checking the presence of Amsdos header.

Useful for CP/M files, or files with Spectrum+3 headers.
